### PR TITLE
test: add toggle button tests for Preview/Code tabs

### DIFF
--- a/src/app/__tests__/main-content.test.tsx
+++ b/src/app/__tests__/main-content.test.tsx
@@ -1,0 +1,111 @@
+import { test, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MainContent } from "../main-content";
+
+// Mock heavy dependencies
+vi.mock("@/lib/contexts/file-system-context", () => ({
+  FileSystemProvider: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/lib/contexts/chat-context", () => ({
+  ChatProvider: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/chat/ChatInterface", () => ({
+  ChatInterface: () => <div data-testid="chat-interface">Chat</div>,
+}));
+
+vi.mock("@/components/editor/FileTree", () => ({
+  FileTree: () => <div data-testid="file-tree">FileTree</div>,
+}));
+
+vi.mock("@/components/editor/CodeEditor", () => ({
+  CodeEditor: () => <div data-testid="code-editor">CodeEditor</div>,
+}));
+
+vi.mock("@/components/preview/PreviewFrame", () => ({
+  PreviewFrame: () => <div data-testid="preview-frame">PreviewFrame</div>,
+}));
+
+vi.mock("@/components/HeaderActions", () => ({
+  HeaderActions: () => <div data-testid="header-actions">HeaderActions</div>,
+}));
+
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => <div />,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+test("renders Preview tab as active by default", () => {
+  render(<MainContent />);
+
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+
+  expect(previewTab.getAttribute("data-state")).toBe("active");
+  expect(codeTab.getAttribute("data-state")).toBe("inactive");
+});
+
+test("shows PreviewFrame by default", () => {
+  render(<MainContent />);
+
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+});
+
+test("clicking Code tab switches to code view", () => {
+  render(<MainContent />);
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  fireEvent.click(codeTab);
+
+  expect(screen.getByTestId("code-editor")).toBeDefined();
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+});
+
+test("clicking Code tab makes it active", () => {
+  render(<MainContent />);
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  fireEvent.click(codeTab);
+
+  expect(codeTab.getAttribute("data-state")).toBe("active");
+  expect(screen.getByRole("tab", { name: "Preview" }).getAttribute("data-state")).toBe("inactive");
+});
+
+test("clicking Preview tab after Code switches back to preview", () => {
+  render(<MainContent />);
+
+  // Switch to code view
+  fireEvent.click(screen.getByRole("tab", { name: "Code" }));
+  expect(screen.getByTestId("code-editor")).toBeDefined();
+
+  // Switch back to preview
+  fireEvent.click(screen.getByRole("tab", { name: "Preview" }));
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+});
+
+test("clicking Preview tab after Code makes it active again", () => {
+  render(<MainContent />);
+
+  fireEvent.click(screen.getByRole("tab", { name: "Code" }));
+  fireEvent.click(screen.getByRole("tab", { name: "Preview" }));
+
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  expect(previewTab.getAttribute("data-state")).toBe("active");
+});


### PR DESCRIPTION
Add tests verifying that the Preview/Code toggle buttons correctly switch between views.

Closes #2

Generated with [Claude Code](https://claude.ai/code)